### PR TITLE
Moves contest listings from private to public wiki

### DIFF
--- a/content/wiki/_index.md
+++ b/content/wiki/_index.md
@@ -14,4 +14,5 @@ Here you can find some general information to help you with organizing a Program
 * [Hosting a preliminary](/wiki/hosting-a-preliminary/)
 * [Organizing your first ICPC style contest](/wiki/organizing-a-first-year-contest---setting-up-an-icpc-style-contest/)
 * [Coaching a team](/wiki/coaching-a-team/)
+* [Contests archive](/wiki/contests/)
 

--- a/content/wiki/contests.md
+++ b/content/wiki/contests.md
@@ -1,0 +1,39 @@
+---
+title: "Contest Overview"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+## BAPC
+| Year             | City             | Institution                        |
+|------------------|------------------|------------------------------------|
+| [2022](bapc2022) | Eindhoven        | Eindhoven University of Technology |
+| [2021](bapc2021) | Amsterdam        | Vrije Universiteit Amsterdam       |
+| [2020](bapc2020) | Delft            | Technische Universiteit Delft      |
+| [2019](bapc2019) | Nijmegen         | Radboud Universiteit               |
+| [2018](#) (todo) | Louvain-la-Neuve | Université catholique de Louvain   |
+| [2017](#) (todo) | Amsterdam        | Universiteit van Amsterdam         |
+| [2016](bapc2016) | Delft            | Technische Universiteit Delft      |
+| [2015](#) (todo) | Leiden           | Universiteit Leiden                |
+| [2014](bapc2014) | Eindhoven        | Technische Universiteit Eindhoven  |
+| [2013](#) (todo) | Utrecht          | Universiteit Utrecht               |
+| [2012](#) (todo) | Utrecht          | Universiteit Utrecht               |
+| [2011](bapc2011) | Eindhoven        | Technische Universiteit Eindhoven  |
+| [2010](#) (todo) | Leiden           | Universiteit Leiden                |
+| [2009](#) (todo) | Groningen        | Rijksuniversiteit Groningen        | 
+| [2008](#) (todo) | Delft            | Technische Universiteit Delft      |
+| [2007](#) (todo) | Enschede         | Universiteit Twente                |
+| [2006](#) (todo) | Leiden           | Universiteit Leiden                |
+| [2005](#) (todo) | Delft            | Technische Universiteit Delft      |
+
+
+## NWERCs held in the Benelux
+| Year              | City      | Institution                       |
+|-------------------|-----------|-----------------------------------|
+| [2022](nwerc2022) | Delft     | Delft University of Technology    |
+| [2019](nwerc2019) | Eindhoven | Technische Universiteit Eindhoven |
+| [2018](nwerc2018) | Eindhoven | Technische Universiteit Eindhoven |
+| [2013](nwerc2013) | Delft     | Technische Universiteit Delft     |
+| [2012](nwerc2012) | Delft     | Technische Universiteit Delft     |
+| [2008](#) (todo)  | Utrecht   | Universiteit Utrecht              |
+| [2007](#) (todo)  | Utrecht   | Universiteit Utrecht              |

--- a/content/wiki/contests/BAPC2011.md
+++ b/content/wiki/contests/BAPC2011.md
@@ -1,0 +1,39 @@
+---
+title: "BAPC 2011"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+[back][home]
+
+# BAPC 2011
+
+
+|            |                    |
+|------------|-------------------:|
+| Host       |       TU Eindhoven |
+| Organizer  |              GEWIS |
+| Committee  |    [GEHACK][email] |
+| BAPC Date  |  October 15th 2011 | 
+| website    |    [link][website] |
+| Pictures   |     [link][photos] |
+| Scoreboard | [link][scoreboard] |
+| Problemset | [link][problemset] |
+| Teams      |                 27 |
+
+## Problemset
+|Contest | Problemset, solutions and presentation |
+|---|---|
+| BAPC | [link][problemset] |
+| Prelinaries | [link](http://2011.bapc.eu/Preliminaries.zip) |
+
+## Preliminaries
+The preliminaries were held on October 1st 2011.
+The scoreboards and number of teams of the preliminaries are lost to time.
+
+[home]: index.md
+[website]: https://2011.bapc.eu/
+[email]: mailto:gehack@gewis.nl
+[photos]: https://www.gewis.nl/photo/album/1096
+[scoreboard]: http://2011.bapc.eu/scoreboard/
+[problemset]: http://2011.bapc.eu/Finals.zip

--- a/content/wiki/contests/BAPC2014.md
+++ b/content/wiki/contests/BAPC2014.md
@@ -1,0 +1,35 @@
+---
+title: "BAPC 2014"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+
+|            |                    |
+|------------|-------------------:|
+| Host       |       TU Eindhoven |
+| Organizer  |              GEWIS |
+| Committee  |    [GEHACK][email] |
+| BAPC Date  |  October 19th 2014 | 
+| website    |    [link][website] |
+| Pictures   |     [link][photos] |
+| Scoreboard | [link][scoreboard] |
+| Problemset | [link][problemset] |
+| Teams      |                 35 |
+
+## Problemset
+|Contest | Problemset, solutions and presentation |
+|---|---|
+| BAPC | [link][problemset] |
+| Prelinaries | [link](https://2014.bapc.eu/preliminary.zip) |
+
+## Preliminaries
+The preliminaries were held on September 27th, and October 4th 2014.
+The scoreboards and number of teams of the preliminaries are lost to time.
+
+[home]: index.md
+[website]: https://2014.bapc.eu/
+[email]: mailto:gehack@gewis.nl
+[photos]: https://www.gewis.nl/photo/album/827
+[scoreboard]: http://2014.bapc.eu/scoreboards/bapc/
+[problemset]: https://2014.bapc.eu/problemset.zip

--- a/content/wiki/contests/BAPC2016.md
+++ b/content/wiki/contests/BAPC2016.md
@@ -1,0 +1,51 @@
+---
+title: "BAPC 2016"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                                 |
+|------------|--------------------------------:|
+| Host       |                        TU Delft |
+| Organizer  | W.I.S.V. \`Christiaan Huygens\` |
+| Committee  |                [CHipCie][email] |
+| BAPC Date  |               October 22nd 2016 | 
+| website    |                 [link][website] |
+| Pictures   |                  [link][photos] |
+| Scoreboard |              [link][scoreboard] |
+| Problemset |              [link][problemset] |
+| Teams      |                              51 |
+
+## Problemset
+
+The preliminaries were held on September 24 2016.
+
+| Contest     | Problemset                                                                       | Solutions                                                                       | Presentation                                                                    |
+|-------------|----------------------------------------------------------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| BAPC        | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2016/bapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2016/bapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2016/bapc/solutions.pdf) 
+| Prelinaries | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2016/dapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2016/dapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2016/dapc/solutions.pdf) |
+
+## Preliminaries
+
+| Institution        |  Teams  | Scoreboard                                                                                                                          |
+|--------------------|:-------:|-------------------------------------------------------------------------------------------------------------------------------------|
+| TU Delft           |   10    | [link](https://2016.bapc.eu/media/filer_public_thumbnails/filer_public/2016/09/30/dapc.png__902x782_q85.png)                        | 
+| TU Eindhoven       |   12    | [link](https://2016.bapc.eu/media/filer_public_thumbnails/filer_public/2016/09/30/eapc.png__979x674_q85_crop_upscale.png)           |
+| Leiden University  |    6    | [link](https://2016.bapc.eu/media/filer_public_thumbnails/filer_public/2016/09/30/lapc.png__905x639_q85_crop_upscale.png)           |
+| Radboud University |    6    | [link](https://2016.bapc.eu/media/filer_public_thumbnails/filer_public/2016/09/30/nkp.png__923x486_q85_crop_upscale.png)            |
+| VU                 |   10    | [link](https://2016.bapc.eu/media/filer_public_thumbnails/filer_public/2016/10/03/aapp.png__910x687_q85_crop_upscale.jpg)           |
+| UvA                |    5    | [link](https://2016.bapc.eu/media/filer_public_thumbnails/filer_public/2016/09/30/uva.png__879x294_q85_crop_upscale.jpg)            |
+| Utrecht University |    3    | [link](https://2016.bapc.eu/media/filer_public_thumbnails/filer_public/2016/09/30/scorebord_ukp.png__1335x375_q85_crop_upscale.jpg) |
+| Total              | **52**  |                                                                                                                                     |
+
+[home]: index.md
+
+[website]: https://2016.bapc.eu/
+
+[email]: mailto:chipcie@ch.tudelft.nl
+
+[photos]: https://flitcie.ch.tudelft.nl/60/BAPC
+
+[scoreboard]: https://2016.bapc.eu/en/results/
+
+[problemset]: http://commissies.ch.tudelft.nl/chipcie/archive/2016/bapc/problemset.pdf

--- a/content/wiki/contests/BAPC2019.md
+++ b/content/wiki/contests/BAPC2019.md
@@ -4,13 +4,12 @@ date: 2022-11-29T21:57:18+01:00
 menu: "wiki"
 ---
 
-
 |            |                              |
 |------------|-----------------------------:|
 | Host       |  Radboud university Nijmegen |
 | Organizer  |             Desda and Thalia |
 | Committee  | [2019 BAPC Committee][email] |
-| BAPC Date  |       October {date}  {year} | 
+| BAPC Date  |              October 19 2019 | 
 | Website    |              [link][website] |
 | Pictures   |               [link][photos] |
 | Scoreboard |           [link][scoreboard] |
@@ -18,13 +17,13 @@ menu: "wiki"
 | Teams      |                           56 |
 
 ## Problemset
-| Contest     | Problemset                                                                         | Solutions                                                                         | Presentation                                                                      |
-|-------------|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| BAPC        | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/solutions.pdf) 
-| Prelinaries | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/solutions.pdf) |
+| Contest     | Problemset                                                                       | Solutions                                                                     | Presentation                                                                      |
+|-------------|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| BAPC        | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2019/bapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2019/bapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2019/bapc/solutions.pdf) | 
+| Prelinaries | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2019/dapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2019/dapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2019/dapc/solutions.pdf) |
 
 ## Preliminaries
-The preliminaries were held on September {date} {year}.
+The preliminaries were held on September 21 2019.
 
 | Institution | Scoreboard                                |
 |-------------|-------------------------------------------|
@@ -34,7 +33,6 @@ The preliminaries were held on September {date} {year}.
 [website]: https://2019.bapc.eu/
 [email]: mailto:bapc2019@thalia.nu
 [photos]: https://thalia.nu/members/photos/19-10-2019-bapc-2019/a3ce14a3b41bd36da2d81cc2e52ba77412a85f4b4d0a1cf8df907c48fad06df9/
-[scoreboard]: https://{year}.bapc.eu/en/results/
-[problemset]: http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/problemset.pdf
-[date]: 19
+[scoreboard]: https://2019.bapc.eu/en/results/
+[problemset]: http://commissies.ch.tudelft.nl/chipcie/archive/2019/bapc/problemset.pdf
  

--- a/content/wiki/contests/BAPC2019.md
+++ b/content/wiki/contests/BAPC2019.md
@@ -1,0 +1,40 @@
+---
+title: "BAPC 2019"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+
+|            |                              |
+|------------|-----------------------------:|
+| Host       |  Radboud university Nijmegen |
+| Organizer  |             Desda and Thalia |
+| Committee  | [2019 BAPC Committee][email] |
+| BAPC Date  |       October {date}  {year} | 
+| Website    |              [link][website] |
+| Pictures   |               [link][photos] |
+| Scoreboard |           [link][scoreboard] |
+| Problemset |           [link][problemset] |
+| Teams      |                           56 |
+
+## Problemset
+| Contest     | Problemset                                                                         | Solutions                                                                         | Presentation                                                                      |
+|-------------|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| BAPC        | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/solutions.pdf) 
+| Prelinaries | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/solutions.pdf) |
+
+## Preliminaries
+The preliminaries were held on September {date} {year}.
+
+| Institution | Scoreboard                                |
+|-------------|-------------------------------------------|
+| Summary     | [link](https://2019.bapc.eu/results.html) |
+
+[home]: index.md
+[website]: https://2019.bapc.eu/
+[email]: mailto:bapc2019@thalia.nu
+[photos]: https://thalia.nu/members/photos/19-10-2019-bapc-2019/a3ce14a3b41bd36da2d81cc2e52ba77412a85f4b4d0a1cf8df907c48fad06df9/
+[scoreboard]: https://{year}.bapc.eu/en/results/
+[problemset]: http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/problemset.pdf
+[date]: 19
+ 

--- a/content/wiki/contests/BAPC2020.md
+++ b/content/wiki/contests/BAPC2020.md
@@ -1,0 +1,33 @@
+---
+title: "BAPC 2020"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                                 |
+|------------|--------------------------------:|
+| Host       |                        TU Delft |
+| Organizer  | W.I.S.V. \`Christiaan Huygens\` |
+| Committee  |                [CHipCie][email] |
+| BAPC Date  |                December 12 2020 | 
+| website    |                 [link][website] |
+| Pictures   |                  [link][photos] |
+| Scoreboard |              [link][scoreboard] |
+| Problemset |              [link][problemset] |
+| Teams      |                              78 |
+
+## Problemset
+| Contest     | Problemset                                                                       | Solutions                                                                       | Presentation                                                                    |
+|-------------|----------------------------------------------------------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| BAPC        | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2020/bapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2020/bapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2020/bapc/solutions.pdf) |
+| Prelinaries | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2020/dapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2020/dapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/2020/dapc/solutions.pdf) |
+
+## Preliminaries
+The preliminaries were held on November 14 2020.
+
+[home]: index.md
+[website]: https://2020.bapc.eu/
+[email]: mailto:chipcie@ch.tudelft.nl
+[photos]: https://
+[scoreboard]: https://2020.bapc.eu/scoreboard
+[problemset]: http://commissies.ch.tudelft.nl/chipcie/archive/2020/bapc/problemset.pdf

--- a/content/wiki/contests/BAPC2021.md
+++ b/content/wiki/contests/BAPC2021.md
@@ -1,0 +1,32 @@
+---
+title: "BAPC 2021"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                              |
+|------------|-----------------------------:|
+| Host       | Vrije Universiteit Amsterdam |
+| Organizer  |                        STORM |
+| Committee  |                [AAPP][email] |
+| BAPC Date  |              October 30 2021 |
+| website    |              [link][website] |
+| Pictures   |               [link][photos] |
+| Scoreboard |           [link][scoreboard] |
+| Problemset |           [link][problemset] |
+| Teams      |                           71 |
+
+## Problemset
+| Contest     | Problemset                                            | Solutions                                              | Presentation                                                                      |
+|-------------|-------------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------|
+| BAPC        | [link](https://2021.bapc.eu/bapc2021-problems.pdf)    | [link](https://2021.bapc.eu/bapc2021-solutions.pdf)    | [link](https://commissies.ch.tudelft.nl/chipcie/archive/2021/bapc/solutions.pdf)  |
+| Prelinaries | [link](https://2021.bapc.eu/prelims2021-problems.pdf) | [link](https://2021.bapc.eu/prelims2021-solutions.pdf) | [link](https://commissies.ch.tudelft.nl/chipcie/archive/2021/dapc/solutions.pdf)  |
+
+## Preliminaries
+The preliminaries were held on October 9 2021.
+
+[website]: https://2021.bapc.eu/
+[email]: mailto:contact@2021.bapc.eu
+[photos]: https://2021.bapc.eu/photos/
+[scoreboard]: https://2021.bapc.eu/BAPC21.html
+[problemset]: https://2021.bapc.eu/bapc2021-problems.pdf

--- a/content/wiki/contests/BAPC2022.md
+++ b/content/wiki/contests/BAPC2022.md
@@ -1,0 +1,35 @@
+---
+title: "BAPC 2022"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                                    |
+|------------|-----------------------------------:|
+| Host       | Eindhoven University of Technology |
+| Organizer  |                              GEWIS |
+| Committee  |                    [GEHACK][email] |
+| BAPC Date  |                    October 22 2022 | 
+| website    |                    [link][website] |
+| Pictures   |       (unavailable) [link][photos] |
+| Scoreboard |                 [link][scoreboard] |
+| Problemset |                 [link][problemset] |
+| Teams      |                                 50 |
+
+For this BAPC the choice was made to explicitly shrink the number of contestants to make the event easier to organise in future years.
+
+## Problemset
+| Contest     | Problemset                                              | Solutions                                                                        | Presentation                                             |
+|-------------|---------------------------------------------------------|----------------------------------------------------------------------------------|----------------------------------------------------------|
+| BAPC        | [link](https://2022.bapc.eu/bapc/problems.pdf)          | [link](https://commissies.ch.tudelft.nl/chipcie/archive/2022/bapc/solutions.zip) | [link](https://2022.bapc.eu/bapc/solutions.pdf)          |
+| Prelinaries | [link](https://2022.bapc.eu/preliminaries/problems.pdf) | [link](https://commissies.ch.tudelft.nl/chipcie/archive/2022/dapc/solutions.zip) | [link](https://2022.bapc.eu/preliminaries/solutions.pdf) |
+
+## Preliminaries
+The preliminaries were held on September 24 2022.
+
+[home]: index.md
+[website]: https://2022.bapc.eu/
+[email]: mailto:gehack@gewis.nl
+[photos]: #
+[scoreboard]: https://2022.bapc.eu/bapc/scoreboard/
+[problemset]: https://2022.bapc.eu/bapc/problems.pdf

--- a/content/wiki/contests/NWERC2012.md
+++ b/content/wiki/contests/NWERC2012.md
@@ -1,0 +1,39 @@
+---
+title: "NWERC 2012"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                                 |
+|------------|---------------------------------|
+| Host       | TU  Delft                       |
+| Organizer  | W.I.S.V. \`Christiaan Huygens\` |
+| Committee  | [CHipCie][email]                |
+| NWERC Date | November 23-25 2012             | 
+| website    | [link][website]                 |
+| Pictures   | [link][photos]                  |
+| Scoreboard | [link][scoreboard]              |
+| Teams      | 85                              |
+
+## Problemsets
+
+### Contest
+
+| Contest          | Problemset, solutions and presentation                                           |
+|------------------|----------------------------------------------------------------------------------|
+| Problemset       | [link][problemset]                                                               |
+| Solutions slides | [link](http://2012.nwerc.eu/media/ProblemSet-presentation.pdf)                   |
+| Problem packages | [link](http://2012.nwerc.eu/media/NWERC_2012_ProblemSet_TestCases_Solutions.zip) |
+
+[home]: index.md
+
+[website]: https://2012.nwerc.eu/
+
+[email]: mailto:chipcie@ch.tudelft.nl
+
+[photos]: https://flitcie.ch.tudelft.nl/56/NWERC-2012
+
+[scoreboard]: https://2012.nwerc.eu/en/results/scoreboard/
+
+[problemset]: http://2012.nwerc.eu/media/NWERC_2012_ProblemSet_FINAL.pdf
+

--- a/content/wiki/contests/NWERC2013.md
+++ b/content/wiki/contests/NWERC2013.md
@@ -1,0 +1,41 @@
+---
+title: "NWERC 2013"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                                 |
+|------------|---------------------------------|
+| Host       | TU  Delft                       |
+| Organizer  | W.I.S.V. \`Christiaan Huygens\` |
+| Committee  | [CHipCie][email]                |
+| NWERC Date | November 22-24 2013             | 
+| website    | [link][website]                 |
+| Pictures   | [link][photos]                  |
+| Scoreboard | [link][scoreboard]              |
+| Teams      | 96                              |
+
+## Problemsets
+
+### Practice
+
+| Contest    | Problem, solutions and presentation |
+|------------|-------------------------------------|
+| Problemset | [link][practiceset]                 |
+
+
+### Contest
+
+| Contest                             | Problemset, solutions and presentation                                                                  |
+|-------------------------------------|---------------------------------------------------------------------------------------------------------|
+| Problemset                          | [link][problemset]                                                                                      |
+| Solutions slides + problem packages | [link](https://2013.nwerc.eu/media/filer_public/2013/12/03/nwerc-2013-problems-solutions-testcases.zip) |
+
+[home]: index.md
+
+[website]: https://2013.nwerc.eu/
+[email]: mailto:chipcie@ch.tudelft.nl
+[photos]: https://photos.app.goo.gl/8NENxkzGXtDfh9fw8
+[scoreboard]: https://2013.nwerc.eu/en/results/scoreboard/
+[problemset]: http://2013.nwerc.eu/media/filer_public/2013/11/24/nwerc_2013_problemset_contest.pdf
+[practiceset]: http://2013.nwerc.eu/media/filer_public/2013/11/23/nwerc_2013_problemset_testsession.pdf

--- a/content/wiki/contests/NWERC2018.md
+++ b/content/wiki/contests/NWERC2018.md
@@ -1,0 +1,45 @@
+---
+title: "NWERC 2018"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                     |
+|------------|--------------------:|
+| Host       |        TU Eindhoven |
+| Organizer  |               GEWIS |
+| Committee  |     [GEHACK][email] |
+| NWERC Date | November 23-25 2018 | 
+| website    |     [link][website] |
+| Pictures   |      [link][photos] |
+| Scoreboard |  [link][scoreboard] |
+| Teams      |                 119 |
+
+## Problemsets
+
+### Practice
+
+| Contest          | Problemset, solutions and presentation                          |
+|------------------|-----------------------------------------------------------------|
+| Problemset       | [link][practiceset]                                             |
+| Solutions slides | [link](https://2018.nwerc.eu/files/nwerc2018practiceslides.pdf) |
+| Problem packages | [link](https://2018.nwerc.eu/files/nwerc2018practice.tar.bz2)   |
+
+
+### Contest
+
+| Contest          | Problemset, solutions and presentation                          |
+|------------------|-----------------------------------------------------------------|
+| Problemset       | [link][problemset]                                              |
+| Solutions slides | [link](https://2018.nwerc.eu/files/nwerc2018slides-handout.pdf) |
+| Problem packages | [link](https://2018.nwerc.eu/files/nwerc2018all.tar.bz2)        |
+
+
+
+[home]: index.md
+[website]: https://2018.nwerc.eu/
+[email]: mailto:gehack@gewis.nl
+[photos]: https://2018.nwerc.eu/photos/
+[scoreboard]: https://2018.nwerc.eu/scoreboard/
+[problemset]: https://2018.nwerc.eu/files/nwerc2018problems.pdf
+[practiceset]: https://2018.nwerc.eu/files/nwerc2018practice.pdf

--- a/content/wiki/contests/NWERC2019.md
+++ b/content/wiki/contests/NWERC2019.md
@@ -1,0 +1,46 @@
+---
+title: "NWERC 2019"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+
+|            |                       |
+|------------|----------------------:|
+| Host       |          TU Eindhoven |
+| Organizer  |                 GEWIS |
+| Committee  |       [GEHACK][email] |
+| BAPC Date  |   November 15-17 2019 | 
+| website    |       [link][website] |
+| Pictures   |        [link][photos] |
+| Scoreboard |    [link][scoreboard] |
+| Teams      |                   123 |
+
+## Problemsets
+
+### Practice
+
+|Contest | Problemset, solutions and presentation |
+|---|---|
+| Problemset | [link][practiceset]|
+| Solutions slides | [link](https://2019.nwerc.eu/files/nwerc2019practice-slides.pdf)|
+| Problem packages | [link](https://2019.nwerc.eu/files/nwerc2019practice.tar.bz2) |
+
+
+### Contest
+
+|Contest | Problemset, solutions and presentation |
+|---|---|
+| Problemset | [link][problemset]|
+| Solutions slides | [link](https://2019.nwerc.eu/files/nwerc2019slides.pdf)|
+| Problem packages | [link](https://2019.nwerc.eu/files/nwerc2019all.tar.bz2) |
+
+
+
+[home]: index.md
+[website]: https://2019.nwerc.eu/
+[email]: mailto:gehack@gewis.nl
+[photos]: https://2019.nwerc.eu/photos/
+[scoreboard]: https://2019.nwerc.eu/scoreboard/
+[problemset]: https://2019.nwerc.eu/files/nwerc2019problems.pdf
+[practiceset]: https://2019.nwerc.eu/files/nwerc2019practice.pdf

--- a/content/wiki/contests/NWERC2022.md
+++ b/content/wiki/contests/NWERC2022.md
@@ -1,0 +1,45 @@
+---
+title: "NWERC 2022"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+|            |                                 |
+|------------|--------------------------------:|
+| Host       |  Delft University of Technology |
+| Organizer  | W.I.S.V. \`Christiaan Huygens\` |
+| Commitee   |                [Chipcie][email] |
+| NWERC Date |             November 25-27 2022 | 
+| website    |                 [link][website] |
+| Pictures   |   (unavailable) [link][photos]  |
+| Scoreboard |              [link][scoreboard] |
+| Teams      |                             140 |
+
+## Problemsets
+
+### Practice
+
+| Contest          | Problemset, solutions and presentation                                            |
+|------------------|-----------------------------------------------------------------------------------|
+| Problemset       | [link][practiceset]                                                               |
+| Solutions slides | [link](https://2022.nwerc.eu/main/solutions.pdf)                                  |
+| Problem packages | [link](https://2022.nwerc.eu/test-session/solutions.zip) |
+
+
+### Contest
+
+| Contest          | Problemset, solutions and presentation                   |
+|------------------|----------------------------------------------------------|
+| Problemset       | [link][problemset]                                       |
+| Solutions slides | [link](https://2022.nwerc.eu/test-session/solutions.pdf)  |
+| Problem packages | [link](https://commissies.ch.tudelft.nl/chipcie/archive/2022/nwerc/solutions.zip) |
+
+
+
+[home]: index.md
+[website]: https://2022.nwerc.eu/
+[email]: mailto:contact@2022.nwerc.eu
+[photos]: #
+[scoreboard]: https://2022.nwerc.eu/main/scoreboard/
+[problemset]: https://2022.nwerc.eu/test-session/problem-set.pdf
+[practiceset]: https://2019.nwerc.eu/files/nwerc2019practice.pdf

--- a/content/wiki/contests/NWERC2022.md
+++ b/content/wiki/contests/NWERC2022.md
@@ -9,7 +9,7 @@ menu: "wiki"
 | Host       |  Delft University of Technology |
 | Organizer  | W.I.S.V. \`Christiaan Huygens\` |
 | Commitee   |                [Chipcie][email] |
-| NWERC Date |             November 25-27 2022 | 
+| NWERC Date |             November 25-27 2022 |
 | website    |                 [link][website] |
 | Pictures   |   (unavailable) [link][photos]  |
 | Scoreboard |              [link][scoreboard] |
@@ -21,17 +21,17 @@ menu: "wiki"
 
 | Contest          | Problemset, solutions and presentation                                            |
 |------------------|-----------------------------------------------------------------------------------|
-| Problemset       | [link][practiceset]                                                               |
-| Solutions slides | [link](https://2022.nwerc.eu/main/solutions.pdf)                                  |
-| Problem packages | [link](https://2022.nwerc.eu/test-session/solutions.zip) |
+| Problemset       | [link](https://2022.nwerc.eu/test-session/problem-set.pdf)                        |
+| Solutions slides | [link](https://2022.nwerc.eu/test-session/solutions.pdf)                          |
+| Problem packages | [link](https://2022.nwerc.eu/test-session/solutions.zip)                          |
 
 
 ### Contest
 
-| Contest          | Problemset, solutions and presentation                   |
-|------------------|----------------------------------------------------------|
-| Problemset       | [link][problemset]                                       |
-| Solutions slides | [link](https://2022.nwerc.eu/test-session/solutions.pdf)  |
+| Contest          | Problemset, solutions and presentation                                            |
+|------------------|-----------------------------------------------------------------------------------|
+| Problemset       | [link](https://2022.nwerc.eu/main/problem-set.pdf)                                |
+| Solutions slides | [link](https://2022.nwerc.eu/main/solutions.pdf)                                  |
 | Problem packages | [link](https://commissies.ch.tudelft.nl/chipcie/archive/2022/nwerc/solutions.zip) |
 
 
@@ -41,5 +41,3 @@ menu: "wiki"
 [email]: mailto:contact@2022.nwerc.eu
 [photos]: #
 [scoreboard]: https://2022.nwerc.eu/main/scoreboard/
-[problemset]: https://2022.nwerc.eu/test-session/problem-set.pdf
-[practiceset]: https://2019.nwerc.eu/files/nwerc2019practice.pdf

--- a/content/wiki/contests/template.md
+++ b/content/wiki/contests/template.md
@@ -1,0 +1,44 @@
+---
+title: "BAPC {year}"
+date: 2022-11-29T21:57:18+01:00
+menu: "wiki"
+---
+
+
+|            |                        |
+|------------|-----------------------:|
+| Host       |                        |
+| Organizer  |                        |
+| Committee  |              [][email] |
+| BAPC Date  | October {date}  {year} | 
+| Website    |        [link][website] |
+| Pictures   |         [link][photos] |
+| Scoreboard |     [link][scoreboard] |
+| Problemset |     [link][problemset] |
+| Teams      |                {teams} |
+
+## Problemset
+| Contest     | Problemset                                                                         | Solutions                                                                         | Presentation                                                                      |
+|-------------|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| BAPC        | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/solutions.pdf) 
+| Prelinaries | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/problemset.pdf) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/solutions.zip) | [link](http://commissies.ch.tudelft.nl/chipcie/archive/{year}/dapc/solutions.pdf) |
+
+## Preliminaries
+The preliminaries were held on September {date} {year}.
+
+| Institution        | Scoreboard  |
+|--------------------|-------------|
+| TU Delft           | [link]()    |
+| TU Eindhoven       | [link]()    |
+| Leiden University  | [link]()    |
+| Radboud University | [link]()    |
+| VU                 | [link]()    |
+| UvA                | [link]()    |
+| Utrecht University | [link]()    |
+
+[home]: index.md
+[website]: https://{year}.bapc.eu/
+[email]: mailto:chipcie@ch.tudelft.nl
+[photos]: https://
+[scoreboard]: https://{year}.bapc.eu/en/results/
+[problemset]: http://commissies.ch.tudelft.nl/chipcie/archive/{year}/bapc/problemset.pdf


### PR DESCRIPTION
The BAPC21, BAPC22, and NWERC22 contests have also been added. Though they might contain small mistakes.